### PR TITLE
repeat_request

### DIFF
--- a/korea_news_crawler/articlecrawler.py
+++ b/korea_news_crawler/articlecrawler.py
@@ -76,6 +76,16 @@ class ArticleCrawler(object):
                     for page in range(1, totalpage + 1):
                         made_urls.append(url + "&page=" + str(page))
         return made_urls
+    
+    def get_url_data(self, url, max_tries=10):
+        remaining_tries = int(max_tries)
+        while remaining_tries > 0:
+            try:
+                return requests.get(url)
+            except requests.exceptions:
+                time.sleep(60)
+            remaining_tries = remaining_tries - 1
+        raise Exception("Couldn't get the data.")
 
     def crawling(self, category_name):
         # Multi Process PID
@@ -96,7 +106,8 @@ class ArticleCrawler(object):
             regex = re.compile("date=(\d+)")
             news_date = regex.findall(URL)[0]
 
-            request = requests.get(URL)
+            request = self.get_url_data(URL)
+
             document = BeautifulSoup(request.content, 'html.parser')
 
             # html - newsflash_body - type06_headline, type06
@@ -115,7 +126,7 @@ class ArticleCrawler(object):
                 sleep(0.01)
                 
                 # 기사 HTML 가져옴
-                request_content = requests.get(content_url)
+                request_content = self.get_url_data(content_url)
                 document_content = BeautifulSoup(request_content.content, 'html.parser')
 
                 try:


### PR DESCRIPTION
안녕하세요 lumyjuwon 님,

최근으로 올수록 데이터 양이 많아지면서, 서버에서 request를 차단해서 크롤링이 중단되는 일이 종종 생깁니다. 
requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))

오류가 발생해서 프로그램이 종료되는 것을 방지하기 위해서, request 에러가 난 경우에 [sleep(60)을 하고 다시 request]을 10번 반복하는 함수를 넣었습니다. def get_url_data

아래 코드를 참고해서 변경했습니다. 
https://www.reddit.com/r/learnpython/comments/2hpgja/requests_error_max_retries_i_wish_to_wait_and_try/

추가로 readme.md에 과도한 크롤링은 삼가고, 네이버 뉴스 서버의 robots.txt을 참고해서 크롤링하라는 문구와 잘못된 크롤링으로 인한 서버 과부하는 본인에게 책임이 있다는 문구도 넣으면 좋을 것 같은데 어떻게 생각하시나요? :)