### PR TITLE
Repeat request & html error

### DIFF
--- a/korea_news_crawler/articlecrawler.py
+++ b/korea_news_crawler/articlecrawler.py
@@ -76,6 +76,16 @@ class ArticleCrawler(object):
                     for page in range(1, totalpage + 1):
                         made_urls.append(url + "&page=" + str(page))
         return made_urls
+    
+    def get_url_data(self, url, max_tries=10):
+        remaining_tries = int(max_tries)
+        while remaining_tries > 0:
+            try:
+                return requests.get(url)
+            except requests.exceptions:
+                time.sleep(60)
+            remaining_tries = remaining_tries - 1
+        raise Exception("Couldn't get the data.")
 
     def crawling(self, category_name):
         # Multi Process PID
@@ -96,7 +106,8 @@ class ArticleCrawler(object):
             regex = re.compile("date=(\d+)")
             news_date = regex.findall(URL)[0]
 
-            request = requests.get(URL)
+            request = self.get_url_data(URL)
+
             document = BeautifulSoup(request.content, 'html.parser')
 
             # html - newsflash_body - type06_headline, type06
@@ -115,7 +126,7 @@ class ArticleCrawler(object):
                 sleep(0.01)
                 
                 # 기사 HTML 가져옴
-                request_content = requests.get(content_url)
+                request_content = self.get_url_data(content_url)
                 document_content = BeautifulSoup(request_content.content, 'html.parser')
 
                 try:

--- a/korea_news_crawler/articlecrawler.py
+++ b/korea_news_crawler/articlecrawler.py
@@ -127,7 +127,10 @@ class ArticleCrawler(object):
                 
                 # 기사 HTML 가져옴
                 request_content = self.get_url_data(content_url)
-                document_content = BeautifulSoup(request_content.content, 'html.parser')
+                try:
+                    document_content = BeautifulSoup(request_content.content, 'html.parser')
+                except:
+                    continue
 
                 try:
                     # 기사 제목 가져옴


### PR DESCRIPTION
안녕하세요 lumyjuwon 님,

1. 최근으로 올수록 데이터 양이 많아지면서, 네이버 뉴스 서버에서 request를 차단해서 크롤링이 중단되는 일이 종종 생깁니다.
에러문구> requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
오류가 발생해서 프로그램이 종료되는 것을 방지하기 위해서, request 에러가 난 경우에 [sleep(60)을 하고 다시 request]을 10번 반복하는 함수를 넣었습니다. def get_url_data
아래 코드를 참고해서 변경했습니다.
https://www.reddit.com/r/learnpython/comments/2hpgja/requests_error_max_retries_i_wish_to_wait_and_try/




2. 아래 링크된 기사와 같이 BeautifulSoup(request_content.content, 'html.parser') 에서 오류가 나는 경우를 발견했습니다. 이 경우 프로그램이 종료되어서, 예외 처리를 해서 그 기사를 pass 하도록 변경했습니다. (거의 대부분 오류 나지 않음 99.999% 이상)
https://news.naver.com/main/read.nhn?mode=LSD&mid=sec&sid1=101&oid=009&aid=0003061570
기사 소스를 보면 <![[IMAGE1]]> 부분을 html로 parsing하는데 에러가 발생했습니다. 